### PR TITLE
Add Nix Flake to help build on outdated systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This application calculates abstractness and instability metrics for Java, Sprin
 
 It follows the principles of Spring Modulith by analyzing only top-level packages at the same level as the `@SpringBootApplication` annotated class. These packages are expected to be functional layers rather than technical layers (controller, services, repositories etc.).
 
+A [Nix Flake](#nix-flake) is provided to help build on systems with outdated java and maven installations.
+
 ![image](https://github.com/user-attachments/assets/c66e6c52-ccd3-4410-bc0d-ac3941ce122d)
 
 ## Features
@@ -49,6 +51,23 @@ It follows the principles of Spring Modulith by analyzing only top-level package
 4. Click "Scan" to analyze the project
 
 5. View the results in the interactive scatter plot
+
+## Nix Flake
+
+1. Enter development environment
+   ```
+   nix develop
+   ```
+
+2. Build application
+   ```
+   mvn clean package -DskipTests
+   ```
+
+3. Run application
+   ```
+   java -jar target/abstractness-instability-calculator*.jar
+   ```
 
 ## Understanding the Results
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,59 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725910328,
+        "narHash": "sha256-n9pCtzGZ0httmTwMuEbi5E78UQ4ZbQMr1pzi5N0LAG8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5775c2583f1801df7b790bf7f7d710a19bac66f4",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "utils": "utils"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  inputs = {
+    utils.url = "github:numtide/flake-utils";
+  };
+  outputs = { self, nixpkgs, utils }: utils.lib.eachDefaultSystem (system:
+    let
+      pkgs = nixpkgs.legacyPackages.${system};
+      jdk_headless = pkgs.jdk22_headless;
+      maven = pkgs.maven.override { jdk_headless = jdk_headless; };
+    in
+    {
+      devShell = pkgs.mkShell {
+        buildInputs = with pkgs; [
+          maven
+          jdk_headless
+        ];
+      };
+    }
+  );
+}


### PR DESCRIPTION
Older systems like Debian stable and the latest Fedora version don't ship with new enough versions of maven and openjdk.
People will now be able to build the application on all distros with nix installed no matter the host java version.